### PR TITLE
make dnscache compatible with node 0.11 new lookup api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
     - "0.8"
     - "0.10"
+    - "0.11"
+before_install: npm install -g npm

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,16 @@ var EnhanceDns = function (conf) {
                 family = 0;
             } else if (!family) {
                 family = 0;
+            } else if (typeof family === 'object') {
+                if (!family.family) {
+                    family = 0;
+                } else {
+                    family = +family.family;
+                    if (family !== 4 && family !== 6) {
+                        callback(new Error('invalid argument: `family` must be 4 or 6'));
+                        return;
+                    }
+                }
             } else {
                 family = +family;
                 if (family !== 4 && family !== 6) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "dnscache",
     "description": "dnscache for Node",
     "author": "Vinit Sacheti <vsacheti@yahoo.com>",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "dependencies": {
     },
     "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -99,16 +99,20 @@ var tests = [{
     'test_lookup_with_family' : {
         topic : function () {
             var that = this;
-            dns.lookup('127.0.0.1',4, function() {
-                dns.lookup('::1', 6, function(err) {
-                    that.callback(err,dns.internalCache);
+            dns.lookup('127.0.0.1', 4, function() {
+                dns.lookup('::1', 6, function() {
+                    dns.lookup('127.0.0.1', { family: 4, hints: dns.ADDRCONFIG }, function() {
+                        dns.lookup('::1', { family: 6, hints: dns.ADDRCONFIG }, function(err) {
+                            that.callback(err, dns.internalCache);
+                        });
+                    });
                 });
             });
         },
         'verify family4 cache is created' : function (internalCache) {
             assert.isNotNull(internalCache);
-            assert.equal(internalCache.data['lookup_127.0.0.1_4'].hit, 0, 'hit should be 0 for family4');
-            assert.equal(internalCache.data['lookup_::1_6'].hit, 0, 'hit should be 0 for family6');
+            assert.equal(internalCache.data['lookup_127.0.0.1_4'].hit, 1, 'hit should be 1 for family4');
+            assert.equal(internalCache.data['lookup_::1_6'].hit, 1, 'hit should be 1 for family6');
         },
         'test invalid family' : {
             topic : function () {
@@ -133,17 +137,6 @@ var tests = [{
             assert.isNotNull(topic.cache);
             assert.isNotNull(topic.result);
             assert.equal(topic.cache.data['resolve_www.yahoo.com_A'].hit, 0, 'hit should be 0 for resolve');
-        },
-        'test invalid family' : {
-            topic : function () {
-                var that = this;
-                    dns.lookup('127.0.0.1', 7, function(err) {
-                        that.callback(null, err);
-                    });
-            },
-            'verify error is thrown' : function (topic) {
-                assert.isNotNull(topic);
-            }
         }
     },
         


### PR DESCRIPTION
http://nodejs.org/docs/v0.11.14/api/dns.html#dns_dns_lookup_hostname_options_callback

In addition to integer, `family` (now renamed `options`) parameter accepts an object, eg. `{ family: 4, hints: dns.ADDRCONFIG }`.