### PR TITLE
refactored tests for mocha and tweaked some internals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 coverage
+artifacts
 .DS_Store
 .DS_Store?

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,11 @@
+reporting:
+    reports:
+        - lcov
+        - text
+        - text-summary
+check:
+    global:
+        statements: 100
+        lines: 100
+        branches: 100
+        functions: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-    - "0.8"
     - "0.10"
-    - "0.11"
-before_install: npm install -g npm
+    - "0.12"
+    - "4"
+    - "5"
+    - "6"
+before_install: npm install -g npm@latest-2

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -14,7 +14,7 @@ var CacheObject = function (conf) {
 
     this.count = 0;
     this.data = {};
-    var next = global.setImmediate || process.nextTick;
+    var next = require('asap');
 
     this.set = function (key, value, callback) {
         var self = this;
@@ -68,59 +68,52 @@ var CacheObject = function (conf) {
                     self.count = self.count + 1;
                 }
             }
-
-            if (callback) {
-                callback(null, value);
-            }
+            /* jshint -W030 */
+            callback && callback(null, value);
         });
     };
 
     this.get = function (key, callback) {
         var self = this;
+        if (!callback) {
+            throw('cache.get callback is required.');
+        }
 
+        if (!this.data[key]) {
+            return callback(null, undefined);
+        }
         next(function () {
-            if (self.data[key]) {
-                if (conf.ttl !== 0 && (Date.now() - self.data[key].ts) >= self.ttl) {
-                    if (self.data[key].newer) {
-                        if (self.data[key].older) {
-                            // in the middle of the list
-                            self.data[key].newer.older = self.data[key].older;
-                            self.data[key].older.newer = self.data[key].newer;
-                        } else {
-                            // tail
-                            self.tail = self.data[key].newer;
-                            delete self.tail.older;
-                        }
+            var value;
+            if (conf.ttl !== 0 && (Date.now() - self.data[key].ts) >= self.ttl) {
+                if (self.data[key].newer) {
+                    if (self.data[key].older) {
+                        // in the middle of the list
+                        self.data[key].newer.older = self.data[key].older;
+                        self.data[key].older.newer = self.data[key].newer;
                     } else {
-                        // the first item
-                        if (self.data[key].older) {
-                            self.head = self.data[key].older;
-                            delete self.head.newer;
-                        } else {
-                            // 1 items
-                            delete self.head;
-                            delete self.tail;
-                        }
-                    }
-
-                    delete self.data[key];
-                    self.count = self.count - 1;
-
-                    if (callback) {
-                        callback(null, undefined);
+                        // tail
+                        self.tail = self.data[key].newer;
+                        delete self.tail.older;
                     }
                 } else {
-                    self.data[key].hit = self.data[key].hit + 1;
-
-                    if (callback) {
-                        callback(null, self.data[key].val);
+                    // the first item
+                    if (self.data[key].older) {
+                        self.head = self.data[key].older;
+                        delete self.head.newer;
+                    } else {
+                        // 1 items
+                        delete self.head;
+                        delete self.tail;
                     }
                 }
+
+                delete self.data[key];
+                self.count = self.count - 1;
             } else {
-                if (callback) {
-                    callback(null, undefined);
-                }
+                self.data[key].hit = self.data[key].hit + 1;
+                value = self.data[key].val;
             }
+            callback(null, value);
         });
     };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,35 +5,8 @@
 */
 
 var CacheObject = require('./cache.js'),
+    deepCopy = require('lodash.clone'),
     dns = require('dns');
-
-/*
- * Make a deep copy of the supplied object. This function reliably copies only
- * what is valid for a JSON object, array, or other element.
- */
-var deepCopy = function (o) {
-    var newArr, ix, newObj, prop;
-
-    if (!o || typeof o !== 'object') {
-        return o;
-    }
-
-    if (Array.isArray(o)) {
-        newArr = [];
-        for (ix = 0; ix < o.length; ix += 1) {
-            newArr.push(deepCopy(o[ix]));
-        }
-        return newArr;
-    } else {
-        newObj = {};
-        for (prop in o) {
-            if (o.hasOwnProperty(prop)) {
-                newObj[prop] = deepCopy(o[prop]);
-            }
-        }
-        return newObj;
-    }
-};
 
 
 // original function storage
@@ -64,7 +37,7 @@ var EnhanceDns = function (conf) {
                 reverse : dns.reverse
             },
             // cache storage instance
-            cache = conf.cache ? new conf.cache(conf) : new CacheObject(conf);
+            cache = conf.cache ? /*istanbul ignore next*/ new conf.cache(conf) : new CacheObject(conf);
         
         // insert cache object to the instance
         dns.internalCache = cache;
@@ -96,24 +69,23 @@ var EnhanceDns = function (conf) {
 
             cache.get('lookup_' + domain + '_' + family, function (error, record) {
                 if (record) {
-                    callback(error, record.address, record.family);
-                } else {
-                    try{
-                        backup_object.lookup(domain, family, function (err, address, family_r) {
-                            if (err) {
-                                callback(err);
-                            } else {
-                                cache.set('lookup_' + domain + '_' + family, {
-                                    'address' : address,
-                                    'family' : family_r
-                                }, function () {
-                                    callback(err, address, family_r);
-                                });
-                            }
+                    return callback(error, record.address, record.family);
+                }
+                try {
+                    backup_object.lookup(domain, family, function (err, address, family_r) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        cache.set('lookup_' + domain + '_' + family, {
+                            'address' : address,
+                            'family' : family_r
+                        }, function () {
+                            callback(err, address, family_r);
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback(err);
                 }
             });
         };
@@ -132,21 +104,20 @@ var EnhanceDns = function (conf) {
 
             cache.get('resolve_' + domain + '_' + type_new, function (error, record) {
                 if (record) {
-                    callback_new(error, deepCopy(record), true);
-                } else {
-                    try {
-                        backup_object.resolve(domain, type_new, function (err, addresses) {
-                            if (err) {
-                                callback_new(err);
-                            } else {
-                                cache.set('resolve_' + domain + '_' + type_new, addresses, function () {
-                                    callback_new(err, deepCopy(addresses), false);
-                                });
-                            }
+                    return callback_new(error, deepCopy(record), true);
+                }
+                try {
+                    backup_object.resolve(domain, type_new, function (err, addresses) {
+                        if (err) {
+                            return callback_new(err);
+                        }
+                        cache.set('resolve_' + domain + '_' + type_new, addresses, function () {
+                            callback_new(err, deepCopy(addresses), false);
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback_new(err);
                 }
             });
         };
@@ -155,21 +126,20 @@ var EnhanceDns = function (conf) {
         dns.resolve4 = function (domain, callback) {
             cache.get('resolve4_' + domain, function (error, record) {
                 if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    try {
-                        backup_object.resolve4(domain, function (err, addresses) {
-                            if (err) {
-                                callback(err);
-                            } else {
-                                cache.set('resolve4_' + domain, addresses, function () {
-                                    callback(err, deepCopy(addresses));
-                                });
-                            }
+                    return callback(error, deepCopy(record));
+                }
+                try {
+                    backup_object.resolve4(domain, function (err, addresses) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        cache.set('resolve4_' + domain, addresses, function () {
+                            callback(err, deepCopy(addresses));
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback(err);
                 }
             });
         };
@@ -178,21 +148,20 @@ var EnhanceDns = function (conf) {
         dns.resolve6 = function (domain, callback) {
             cache.get('resolve6_' + domain, function (error, record) {
                 if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    try {
-                        backup_object.resolve6(domain, function (err, addresses) {
-                            if (err) {
-                                callback(err);
-                            } else {
-                                cache.set('resolve6_' + domain, addresses, function () {
-                                    callback(err, deepCopy(addresses));
-                                });
-                            }
+                    return callback(error, deepCopy(record));
+                }
+                try {
+                    backup_object.resolve6(domain, function (err, addresses) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        cache.set('resolve6_' + domain, addresses, function () {
+                            callback(err, deepCopy(addresses));
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback(err);
                 }
             });
         };
@@ -201,21 +170,20 @@ var EnhanceDns = function (conf) {
         dns.resolveMx = function (domain, callback) {
             cache.get('resolveMx_' + domain, function (error, record) {
                 if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    try {
-                        backup_object.resolveMx(domain, function (err, addresses) {
-                            if (err) {
-                                callback(err);
-                            } else {
-                                cache.set('resolveMx_' + domain, addresses, function () {
-                                    callback(err, deepCopy(addresses));
-                                });
-                            }
+                    return callback(error, deepCopy(record));
+                }
+                try {
+                    backup_object.resolveMx(domain, function (err, addresses) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        cache.set('resolveMx_' + domain, addresses, function () {
+                            callback(err, deepCopy(addresses));
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback(err);
                 }
             });
         };
@@ -224,21 +192,20 @@ var EnhanceDns = function (conf) {
         dns.resolveTxt = function (domain, callback) {
             cache.get('resolveTxt_' + domain, function (error, record) {
                 if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    try {
-                        backup_object.resolveTxt(domain, function (err, addresses) {
-                            if (err) {
-                                callback(err);
-                            } else {
-                                cache.set('resolveTxt_' + domain, addresses, function () {
-                                    callback(err, deepCopy(addresses));
-                                });
-                            }
+                    return callback(error, deepCopy(record));
+                }
+                try {
+                    backup_object.resolveTxt(domain, function (err, addresses) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        cache.set('resolveTxt_' + domain, addresses, function () {
+                            callback(err, deepCopy(addresses));
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback(err);
                 }
             });
         };
@@ -247,21 +214,20 @@ var EnhanceDns = function (conf) {
         dns.resolveSrv = function (domain, callback) {
             cache.get('resolveSrv_' + domain, function (error, record) {
                 if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    try {
-                        backup_object.resolveSrv(domain, function (err, addresses) {
-                            if (err) {
-                                callback(err);
-                            } else {
-                                cache.set('resolveSrv_' + domain, addresses, function () {
-                                    callback(err, deepCopy(addresses));
-                                });
-                            }
+                    return callback(error, deepCopy(record));
+                }
+                try {
+                    backup_object.resolveSrv(domain, function (err, addresses) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        cache.set('resolveSrv_' + domain, addresses, function () {
+                            callback(err, deepCopy(addresses));
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback(err);
                 }
             });
         };
@@ -270,21 +236,20 @@ var EnhanceDns = function (conf) {
         dns.resolveNs = function (domain, callback) {
             cache.get('resolveNs_' + domain, function (error, record) {
                 if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    try {
-                        backup_object.resolveNs(domain, function (err, addresses) {
-                            if (err) {
-                                callback(err);
-                            } else {
-                                cache.set('resolveNs_' + domain, addresses, function () {
-                                    callback(err, deepCopy(addresses));
-                                });
-                            }
+                    return callback(error, deepCopy(record));
+                }
+                try {
+                    backup_object.resolveNs(domain, function (err, addresses) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        cache.set('resolveNs_' + domain, addresses, function () {
+                            callback(err, deepCopy(addresses));
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback(err);
                 }
             });
         };
@@ -293,21 +258,20 @@ var EnhanceDns = function (conf) {
         dns.resolveCname = function (domain, callback) {
             cache.get('resolveCname_' + domain, function (error, record) {
                 if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    try {
-                        backup_object.resolveCname(domain, function (err, addresses) {
-                            if (err) {
-                                callback(err);
-                            } else {
-                                cache.set('resolveCname_' + domain, addresses, function () {
-                                    callback(err, deepCopy(addresses));
-                                });
-                            }
+                    return callback(error, deepCopy(record));
+                }
+                try {
+                    backup_object.resolveCname(domain, function (err, addresses) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        cache.set('resolveCname_' + domain, addresses, function () {
+                            callback(err, deepCopy(addresses));
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback(err);
                 }
             });
         };
@@ -316,21 +280,20 @@ var EnhanceDns = function (conf) {
         dns.reverse = function (ip, callback) {
             cache.get('reverse_' + ip, function (error, record) {
                 if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    try {
-                        backup_object.reverse(ip, function (err, addresses) {
-                            if (err) {
-                                callback(err);
-                            } else {
-                                cache.set('reverse_' + ip, addresses, function () {
-                                    callback(err, deepCopy(addresses));
-                                });
-                            }
+                    return callback(error, deepCopy(record));
+                }
+                try {
+                    backup_object.reverse(ip, function (err, addresses) {
+                        if (err) {
+                            return callback(err);
+                        }
+                        cache.set('reverse_' + ip, addresses, function () {
+                            callback(err, deepCopy(addresses));
                         });
-                    } catch(err) {
-                        callback(err);
-                    }
+                    });
+                } catch (err) {
+                    /*istanbul ignore next - doesn't throw in node 0.10*/
+                    callback(err);
                 }
             });
         };

--- a/package.json
+++ b/package.json
@@ -2,33 +2,34 @@
     "name": "dnscache",
     "description": "dnscache for Node",
     "author": "Vinit Sacheti <vsacheti@yahoo.com>",
-    "version": "0.0.4",
-    "dependencies": {
-    },
-    "devDependencies": {
-        "jshint": "*",
-        "yui-lint": "*",
-        "istanbul": "*",
-        "vows": "*",
-        "async": "*"
-    },
+    "version": "1.0.0",
     "keywords": [
-        "dnscache", "dns", "nagios"
+        "dnscache",
+        "dns"
     ],
     "main": "./lib/index.js",
     "scripts": {
         "pretest": "jshint --config ./node_modules/yui-lint/jshint.json ./lib/ ./test/",
-        "test": "istanbul cover --print both vows -- --spec ./test/*.js"
+        "test": "jenkins-mocha ./test/*.js",
+        "posttest": "istanbul check-coverage"
     },
-    "bugs": { "url" : "http://github.com/yahoo/dnscache/issues" },
-    "licenses":[
-        {
-            "type" : "BSD",
-            "url" : "https://github.com/yahoo/dnscache/blob/master/LICENSE"
-        }
-    ],
+    "bugs": {
+        "url": "http://github.com/yahoo/dnscache/issues"
+    },
+    "license": "BSD",
     "repository": {
-        "type":"git",
-        "url":"http://github.com/yahoo/dnscache.git"
+        "type": "git",
+        "url": "http://github.com/yahoo/dnscache.git"
+    },
+    "devDependencies": {
+        "async": "~1.5.2",
+        "istanbul": "~0.4.3",
+        "jenkins-mocha": "~2.6.0",
+        "jshint": "~2.9.2",
+        "yui-lint": "~0.2.0"
+    },
+    "dependencies": {
+        "asap": "~2.0.3",
+        "lodash.clone": "~4.3.2"
     }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+/*global describe, it*/
 /*
 * Copyright (c) 2013, Yahoo! Inc. All rights reserved.
 * Copyrights licensed under the New BSD License.
@@ -5,12 +6,14 @@
 */
 
 var assert = require('assert'),
-    vows = require('vows'),
     async = require('async'),
-    mod = require('../lib/index.js')({"enable" : true, "ttl" : 300, "cachesize" : 1000});
+    mod = require('../lib/index.js')({
+        enable: true,
+        ttl: 300,
+        cachesize: 1000
+    });
     
 var dns = require('dns');
-
 var methods = [dns.lookup, dns.resolve, dns.resolve4, dns.resolve6, dns.resolveMx,dns.resolveTxt,
     dns.resolveSrv, dns.resolveNs, dns.resolveCname, dns.reverse];
 var params = ["www.yahoo.com", "www.google.com", "www.google.com", "ipv6.google.com", "yahoo.com",
@@ -19,239 +22,214 @@ var prefix = ['lookup_', 'resolve_', 'resolve4_', 'resolve6_', 'resolveMx_', 're
     'resolveSrv_', 'resolveNs_', 'resolveCname_', 'reverse_'];
 var suffix = ['_0', '_A', 'none', 'none', 'none', 'none', 'none', 'none', 'none', 'none'];
 
-var tests = [{
-    'loading': {
-        topic: function () {
-            return mod;
-        },
-        'should be a function': function (topic) {
-            assert.isNotNull(topic);
-        }
-    },
-   'test_cache_entries_created' : {
-        topic : function () {
-            var that = this, index = 0;
-            async.eachSeries(methods, function(method, cb) {
-                method(params[index], function(err, result) {
-                    if (err) {
-                        console.log(err, index);
-                    }
-                    ++index;
-                    cb(err, result);
-                });
-                }, function (err) {
-                    that.callback(err,dns.internalCache);
+describe('dnscache main test suite', function() {
+    this.timeout(10000); //dns queries are slow..
+
+    it('should export an Object', function () {
+        assert.equal(typeof mod, 'object');
+    });
+
+    it('should verify internal cache is create for each call', function (done) {
+        var index = 0;
+        async.eachSeries(methods, function(method, cb) {
+            method(params[index], function(err, result) {
+                ++index;
+                cb(err, result);
             });
-        },
-        'verify internal cache is create for each call' : function (internalCache) {
-            var index = 0, key;
-            assert.isNotNull(internalCache);
-            for (index = 0; index < methods.length; index ++) {
-                key = suffix[index] !== 'none' ?
-                    prefix[index] + params[index] + suffix[index] : prefix[index] + params[index];
-                assert.isTrue(internalCache.data[key] !== undefined, 'entry not there for ' + key);
-                assert.equal(internalCache.data[key].hit, 0, 'hit should be 0 for ' + key);
-            }
-        },
-        'test_cache_hits' : {
-            topic : function () {
-                var that = this, index = 0;
-                async.eachSeries(methods, function(method, cb) {
-                    method(params[index], function(err, result) {
-                        if (err) {
-                            console.log(err, index);
-                        }
-                        ++index;
-                        cb(err, result);
-                    });
-                }, function (err) {
-                    that.callback(err,dns.internalCache);
-                });
-            },
-            'verify hits are incremented' : function (internalCache) {
-                var index = 0, key;
-                assert.isNotNull(internalCache);
-                for (index = 0; index < methods.length; index ++) {
-                    key = suffix[index] !== 'none' ?
-                    prefix[index] + params[index] + suffix[index] : prefix[index] + params[index];
-                    assert.isTrue(internalCache.data[key] !== undefined, 'entry not there for ' + key);
-                    assert.equal(internalCache.data[key].hit, 1, 'hit should be 1 for ' + key);
-                }
-            },
-            'call_enhance_dns_again' : {
-                topic : function () {
-                    require('../lib/index.js')({"enable" : true, "ttl" : 300, "cachesize" : 1000});
-                    return dns.internalCache;
-                },
-                'verify cache is same as before' : function (internalCache) {
-                    var index = 0, key;
-                    assert.isNotNull(internalCache);
-                    for (index = 0; index < methods.length; index ++) {
-                        key = suffix[index] !== 'none' ?
-                        prefix[index] + params[index] + suffix[index] : prefix[index] + params[index];
-                        assert.isTrue(internalCache.data[key] !== undefined, 'entry not there for ' + key);
-                        assert.equal(internalCache.data[key].hit, 1, 'hit should be 1 for ' + key);
-                    }
-                }
-            }
-        }
-    },
-    'test_lookup_with_family' : {
-        topic : function () {
-            var that = this;
-            dns.lookup('127.0.0.1', 4, function() {
-                dns.lookup('::1', 6, function() {
-                    dns.lookup('127.0.0.1', { family: 4, hints: dns.ADDRCONFIG }, function() {
-                        dns.lookup('::1', { family: 6, hints: dns.ADDRCONFIG }, function(err) {
-                            that.callback(err, dns.internalCache);
+        }, function () {
+            assert.ok(dns.internalCache);
+            methods.forEach(function(name, index) {
+                var key = suffix[index] !== 'none' ? prefix[index] + params[index] + suffix[index] : prefix[index] + params[index];
+                assert.ok(dns.internalCache.data[key], 'entry not there for ' + key);
+                assert.equal(dns.internalCache.data[key].hit, 0, 'hit should be 0 for ' + key);
+            });
+            done();
+        });
+    });
+
+    it('verify hits are incremented', function (done) {
+        var index = 0;
+        async.eachSeries(methods, function(method, cb) {
+            method(params[index], function(err, result) {
+                ++index;
+                cb(err, result);
+            });
+        }, function () {
+            assert.ok(dns.internalCache);
+            methods.forEach(function(name, index) {
+                var key = suffix[index] !== 'none' ? prefix[index] + params[index] + suffix[index] : prefix[index] + params[index];
+                assert.ok(dns.internalCache.data[key], 'entry not there for ' + key);
+                assert.equal(dns.internalCache.data[key].hit, 1, 'hit should be 1 for ' + key);
+            });
+            done();
+        });
+    });
+
+    it('require again and verify cache is same as before', function (done) {
+        require('../lib/index.js')({
+            enable: true, 
+            ttl: 300,
+            cachesize: 1000
+        });
+        assert.ok(dns.internalCache);
+        methods.forEach(function(name, index) {
+            var key = suffix[index] !== 'none' ? prefix[index] + params[index] + suffix[index] : prefix[index] + params[index];
+            assert.ok(dns.internalCache.data[key], 'entry not there for ' + key);
+            assert.equal(dns.internalCache.data[key].hit, 1, 'hit should be 1 for ' + key);
+        });
+        done();
+    });
+
+    it('should verify family4/family6 cache is created for local addresses', function (done) {
+        dns.lookup('127.0.0.1', 4, function() {
+            dns.lookup('::1', 6, function() {
+                dns.lookup('127.0.0.1', { family: 4, hints: dns.ADDRCONFIG }, function() {
+                    dns.lookup('127.0.0.1', { hints: dns.ADDRCONFIG }, function() {
+                        dns.lookup('::1', { family: 6, hints: dns.ADDRCONFIG }, function() {
+                            assert.ok(dns.internalCache);
+                            assert.equal(dns.internalCache.data['lookup_127.0.0.1_4'].hit, 1, 'hit should be 1 for family4');
+                            assert.equal(dns.internalCache.data['lookup_::1_6'].hit, 1, 'hit should be 1 for family6');
+                            done();
                         });
                     });
                 });
             });
-        },
-        'verify family4 cache is created' : function (internalCache) {
-            assert.isNotNull(internalCache);
-            assert.equal(internalCache.data['lookup_127.0.0.1_4'].hit, 1, 'hit should be 1 for family4');
-            assert.equal(internalCache.data['lookup_::1_6'].hit, 1, 'hit should be 1 for family6');
-        },
-        'test invalid family' : {
-            topic : function () {
-                var that = this;
-                    dns.lookup('127.0.0.1', 7, function(err) {
-                        that.callback(null, err);
-                    });
-            },
-            'verify error is thrown' : function (topic) {
-                assert.isNotNull(topic);
-            }
-        }
-    },
-    'test_resolve_with_type' : {
-        topic : function () {
-            var that = this;
-            dns.resolve('www.yahoo.com', 'A', function(err, result) {
-                that.callback(err,{'cache' : dns.internalCache, 'result' : result});
+        });
+    });
+
+    it('should error if the underlying dns method throws', function(done) {
+        var errors = [];
+        async.each(methods, function(method, cb) {
+            method([], function(err) {
+                errors.push(err);
+                cb(null);
             });
-        },
-        'verify resolve cache is created' : function (topic) {
-            assert.isNotNull(topic.cache);
-            assert.isNotNull(topic.result);
-            assert.equal(topic.cache.data['resolve_www.yahoo.com_A'].hit, 0, 'hit should be 0 for resolve');
+        }, function (err) {
+            assert.ok(!err);
+            assert.ok(Array.isArray(errors));
+            assert.ok(errors.length > 0);
+            errors.forEach(function(e) {
+                if (e) { //one node 0.10 method doens't throw
+                    assert.ok((e instanceof Error));
+                }
+            });
+            done();
+        });
+    });
+
+    it('should error on invalid reverse lookup', function(done) {
+        dns.reverse('1.1.1.1', function(err) {
+            assert.ok((err instanceof Error));
+            done();
+        });
+    });
+
+    it('should error on invalid family', function(done) {
+        dns.lookup('127.0.0.1', 7, function(err) {
+            assert.ok((err instanceof Error));
+            done();
+        });
+    });
+
+    it('should error on invalid family Object', function() {
+        dns.lookup('127.0.0.1', { family: 7 }, function(err) {
+            assert.ok((err instanceof Error));
+        });
+    });
+
+    it('should create resolve cache with type', function (done) {
+        dns.resolve('www.yahoo.com', 'A', function(err, result) {
+            assert.ok(dns.internalCache);
+            assert.ok(result);
+            assert.equal(dns.internalCache.data['resolve_www.yahoo.com_A'].hit, 0, 'hit should be 0 for resolve');
+            done();
+        });
+    });
+
+    it('not create a cache from an error in a lookup', function (done) {
+        var index = 0;
+        async.eachSeries(methods, function(method, cb) {
+            method('someerrordata', function(err) {
+                ++index;
+                cb(null, err);
+            });
+        }, function () {
+            methods.forEach(function(name, index) {
+                var key = suffix[index] !== 'none' ? prefix[index] + 'someerrordata' + suffix[index] : prefix[index] + 'someerrordata';
+                assert.equal(dns.internalCache.data[key], undefined, 'entry should not there for ' + key);
+            });
+            done();
+        });
+    });
+
+    it('should not cache by default', function(done) {
+        //if created from other tests
+        if (require('dns').internalCache) {
+            delete require('dns').internalCache;
         }
-    },
+        var testee = require('../lib/index.js')();
+        testee.lookup('127.0.0.1', function() {
+            assert.ok(!dns.internalCache);
+            assert.ok(!require('dns').internalCache);
+            done();
+        });
+    });
+    
+    it('should not cache if enabled: false', function(done) {
+        //if created from other tests
+        if (require('dns').internalCache) {
+            delete require('dns').internalCache;
+        }
+        var testee = require('../lib/index.js')({
+            enable: false
+        });
+
+        testee.lookup('127.0.0.1', function() {
+            assert.ok(!testee.internalCache);
+            assert.ok(!require('dns').internalCache);
+            done();
+        });
+    });
+
+    it('should not cache if cachsize is 0', function(done) {
+        //if created from other tests
+        if (require('dns').internalCache) {
+            delete require('dns').internalCache;
+        }
+        var testee = require('../lib/index.js')({
+            enable: true,
+            cachesize: 0
+        });
+        testee.lookup('127.0.0.1', function() {
+            assert.ok(!testee.internalCache);
+            assert.ok(!require('dns').internalCache);
+            done();
+        });
+    });
+
+    it('should create a cache with default settings', function(done) {
+        //if created from other tests
+        if (require('dns').internalCache) {
+            delete require('dns').internalCache;
+        }
+        var conf = {
+            enable: true
+        },
+        testee = require('../lib/index.js')(conf);
         
-    'test_error_calls' : {
-        topic : function () {
-            var that = this, index = 0;
-            async.eachSeries(methods, function(method, cb) {
-                method('someerrordata', function(err) {
-                    ++index;
-                    cb(null, err);
-                });
-            }, function () {
-                that.callback(null,dns.internalCache);
-            });
-        },
-        'verify no cache is created' : function (err, internalCache) {
-            var index = 0, key;
-            for (index = 0; index < methods.length; index ++) {
-                key = suffix[index] !== 'none' ?
-                    prefix[index] + 'someerrordata' + suffix[index] : prefix[index] + 'someerrordata';
-                assert.isTrue(internalCache.data[key] === undefined, 'entry should not there for ' + key);
-            }
-        }
-    }
-},{
-    test_cache_disabled_by_default : {
-       
-        topic : function() {
-            //if created from other tests
-            if (require('dns').internalCache) {
-                delete require('dns').internalCache;
-            }
-            var that = this,
-                testee = require('../lib/index.js')();
-            testee.lookup('127.0.0.1', function(err) {
-                that.callback(err,testee.internalCache);
-            });
-        },
-        'verify no internal cache' : function (internalCache) {
-            assert.isTrue(!internalCache);
-            assert.isTrue(!require('dns').internalCache);
-            
-        }
-    },
-    test_cache_disabled : {
-       
-        topic : function() {
-            //if created from other tests
-            if (require('dns').internalCache) {
-                delete require('dns').internalCache;
-            }
-            var that = this,
-                testee = require('../lib/index.js')({"enable" : false});
-            testee.lookup('127.0.0.1', function(err) {
-                that.callback(err,testee.internalCache);
-            });
-        },
-        'verify no internal cache' : function (internalCache) {
-            assert.isTrue(!internalCache);
-            assert.isTrue(!require('dns').internalCache);
-            
-        }
-    },
-    test_cache_disabled_cache_size : {
-       
-        topic : function() {
-            //if created from other tests
-            if (require('dns').internalCache) {
-                delete require('dns').internalCache;
-            }
-            var that = this,
-                testee = require('../lib/index.js')({"enable" : true, "cachesize" : 0});
-            testee.lookup('127.0.0.1', function(err) {
-                that.callback(err,testee.internalCache);
-            });
-        },
-        'verify no internal cache' : function (internalCache) {
-            assert.isTrue(!internalCache);
-            assert.isTrue(!require('dns').internalCache);
-            
-        }
-    }
-}, {
-    test_cache_is_created : {
-       
-        topic : function() {
-            //if created from other tests
-            if (require('dns').internalCache) {
-                delete require('dns').internalCache;
-            }
-            var conf = {"enable" : true},
-                that = this, testee = require('../lib/index.js')(conf);
-            testee.lookup('127.0.0.1', function(err) {
-                that.callback(err,{"cache" : testee.internalCache, "conf" : conf});
-            });
-        },
-        'verify cache is created' : function (topic) {
-            assert.isNotNull(topic.cache);
-            assert.equal(topic.cache.data['lookup_127.0.0.1_0'].hit, 0, 'hit should be 0 for family4');
-            assert.isNotNull(dns.internalCache);
+        testee.lookup('127.0.0.1', function() {
+            //verify cache is created
+            assert.ok(testee.internalCache);
+            assert.equal(testee.internalCache.data['lookup_127.0.0.1_0'].hit, 0, 'hit should be 0 for family4');
+            assert.ok(dns.internalCache);
             assert.equal(dns.internalCache.data['lookup_127.0.0.1_0'].hit, 0, 'hit should be 0 for family4');
-        },
-        'verify default values' : function (topic) {
-            assert.isNotNull(topic.conf);
-            assert.equal(topic.conf.ttl, 300);
-            assert.equal(topic.conf.cachesize, 1000);
-        }
-    }
-}];
+            
+            //verify default values
+            assert.ok(conf);
+            assert.equal(conf.ttl, 300);
+            assert.equal(conf.cachesize, 1000);
+            done();
+        });
+    });
 
-var mod_dns_vows = vows.describe('mod');
-for (var i=0;i<tests.length;i++)
-{
-    mod_dns_vows.addBatch(tests[i]);
-}
-mod_dns_vows['export'](module);
-
-// vim: ts=4 sw=4 et
+});


### PR DESCRIPTION
This is a pretty large PR 😄 

I did:

   * Convert test suite to `mocha`
   * Required 100/100/100/100 code coverage
   * Fixed a bug or two while getting to 100^4 code coverage
   * Converted all of the `if/else` for handling errors to be `if (err) { return callback(err); }` style
   * Enforced `callback` on `cache.get`
   * Replaced `deepCopy` with `lodash.close` for perf.
   * Some whitespace tweaks.
   * Added Node 0.12, 4, 5 & 6 to travis config and removed 0.8
   * Bumped the version to `1.0.0` 