### PR TITLE
refactor(duplicate): code into abstracted function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ var EnhanceDns = function (conf) {
             //cache already exists, means this code has already execute ie method are already overwritten
             return dns;
         }
-        
+
         // original function storage
         var backup_object = {
                 lookup : dns.lookup,
@@ -38,7 +38,7 @@ var EnhanceDns = function (conf) {
             },
             // cache storage instance
             cache = conf.cache ? /*istanbul ignore next*/ new conf.cache(conf) : new CacheObject(conf);
-        
+
         // insert cache object to the instance
         dns.internalCache = cache;
 
@@ -122,18 +122,17 @@ var EnhanceDns = function (conf) {
             });
         };
 
-        // override dns.resolve4 method
-        dns.resolve4 = function (domain, callback) {
-            cache.get('resolve4_' + domain, function (error, record) {
+        function override(type, callback, fn) {
+            cache.get(fn + '_' + type, function (error, record) {
                 if (record) {
                     return callback(error, deepCopy(record));
                 }
                 try {
-                    backup_object.resolve4(domain, function (err, addresses) {
+                    backup_object[fn](type, function (err, addresses) {
                         if (err) {
                             return callback(err);
                         }
-                        cache.set('resolve4_' + domain, addresses, function () {
+                        cache.set(fn + '_' + type, addresses, function () {
                             callback(err, deepCopy(addresses));
                         });
                     });
@@ -142,160 +141,46 @@ var EnhanceDns = function (conf) {
                     callback(err);
                 }
             });
+        }
+
+        // override dns.resolve4 method
+        dns.resolve4 = function (domain, callback) {
+            override(domain, callback, 'resolve4');
         };
 
         // override dns.resolve6 method
         dns.resolve6 = function (domain, callback) {
-            cache.get('resolve6_' + domain, function (error, record) {
-                if (record) {
-                    return callback(error, deepCopy(record));
-                }
-                try {
-                    backup_object.resolve6(domain, function (err, addresses) {
-                        if (err) {
-                            return callback(err);
-                        }
-                        cache.set('resolve6_' + domain, addresses, function () {
-                            callback(err, deepCopy(addresses));
-                        });
-                    });
-                } catch (err) {
-                    /*istanbul ignore next - doesn't throw in node 0.10*/
-                    callback(err);
-                }
-            });
+            override(domain, callback, 'resolve6');
         };
 
         // override dns.resolveMx method
         dns.resolveMx = function (domain, callback) {
-            cache.get('resolveMx_' + domain, function (error, record) {
-                if (record) {
-                    return callback(error, deepCopy(record));
-                }
-                try {
-                    backup_object.resolveMx(domain, function (err, addresses) {
-                        if (err) {
-                            return callback(err);
-                        }
-                        cache.set('resolveMx_' + domain, addresses, function () {
-                            callback(err, deepCopy(addresses));
-                        });
-                    });
-                } catch (err) {
-                    /*istanbul ignore next - doesn't throw in node 0.10*/
-                    callback(err);
-                }
-            });
+            override(domain, callback, 'resolveMx');
         };
 
         // override dns.resolveTxt method
         dns.resolveTxt = function (domain, callback) {
-            cache.get('resolveTxt_' + domain, function (error, record) {
-                if (record) {
-                    return callback(error, deepCopy(record));
-                }
-                try {
-                    backup_object.resolveTxt(domain, function (err, addresses) {
-                        if (err) {
-                            return callback(err);
-                        }
-                        cache.set('resolveTxt_' + domain, addresses, function () {
-                            callback(err, deepCopy(addresses));
-                        });
-                    });
-                } catch (err) {
-                    /*istanbul ignore next - doesn't throw in node 0.10*/
-                    callback(err);
-                }
-            });
+            override(domain, callback, 'resolveTxt');
         };
 
         // override dns.resolveSrv method
         dns.resolveSrv = function (domain, callback) {
-            cache.get('resolveSrv_' + domain, function (error, record) {
-                if (record) {
-                    return callback(error, deepCopy(record));
-                }
-                try {
-                    backup_object.resolveSrv(domain, function (err, addresses) {
-                        if (err) {
-                            return callback(err);
-                        }
-                        cache.set('resolveSrv_' + domain, addresses, function () {
-                            callback(err, deepCopy(addresses));
-                        });
-                    });
-                } catch (err) {
-                    /*istanbul ignore next - doesn't throw in node 0.10*/
-                    callback(err);
-                }
-            });
+            override(domain, callback, 'resolveSrv');
         };
 
         // override dns.resolveNs method
         dns.resolveNs = function (domain, callback) {
-            cache.get('resolveNs_' + domain, function (error, record) {
-                if (record) {
-                    return callback(error, deepCopy(record));
-                }
-                try {
-                    backup_object.resolveNs(domain, function (err, addresses) {
-                        if (err) {
-                            return callback(err);
-                        }
-                        cache.set('resolveNs_' + domain, addresses, function () {
-                            callback(err, deepCopy(addresses));
-                        });
-                    });
-                } catch (err) {
-                    /*istanbul ignore next - doesn't throw in node 0.10*/
-                    callback(err);
-                }
-            });
+            override(domain, callback, 'resolveNs');
         };
 
         // override dns.resolveCname method
         dns.resolveCname = function (domain, callback) {
-            cache.get('resolveCname_' + domain, function (error, record) {
-                if (record) {
-                    return callback(error, deepCopy(record));
-                }
-                try {
-                    backup_object.resolveCname(domain, function (err, addresses) {
-                        if (err) {
-                            return callback(err);
-                        }
-                        cache.set('resolveCname_' + domain, addresses, function () {
-                            callback(err, deepCopy(addresses));
-                        });
-                    });
-                } catch (err) {
-                    /*istanbul ignore next - doesn't throw in node 0.10*/
-                    callback(err);
-                }
-            });
+            override(domain, callback, 'resolveCname');
         };
 
         // override dns.reverse method
         dns.reverse = function (ip, callback) {
-            cache.get('reverse_' + ip, function (error, record) {
-                if (record) {
-                    return callback(error, deepCopy(record));
-                }
-                try {
-                    backup_object.reverse(ip, function (err, addresses) {
-                        if (err) {
-                            return callback(err);
-                        }
-                        cache.set('reverse_' + ip, addresses, function () {
-                            callback(err, deepCopy(addresses));
-                        });
-                    });
-                } catch (err) {
-                    /*istanbul ignore next - doesn't throw in node 0.10*/
-                    callback(err);
-                }
-            });
+            override(ip, callback, 'reverse');
         };
         return dns;
 };


### PR DESCRIPTION
`cache.get()` code  at `dns.resolve4`, `dns.resolve6`, `dns.resolveMx`, `dns.resolveTxt`, `dns.resolveSrv`, `dns.resolveNs`, `dns.resolveCname`, `dns.reverse` had been almost same.
