### PR TITLE
support lookup all.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,7 @@ var EnhanceDns = function (conf) {
                         return;
                     }
                 }
+                /*istanbul ignore next - "hints" require node 0.12+*/
                 if (options.hints) {
                     hints = +options.hints;
                 }
@@ -72,7 +73,7 @@ var EnhanceDns = function (conf) {
 
             cache.get('lookup_' + domain + '_' + family + '_' + hints + '_' + all, function (error, record) {
                 if (record) {
-                    // Returns array if support "all" option and enabled.
+                    /*istanbul ignore next - "all" option require node 4+*/
                     if (Array.isArray(record)) {
                         return callback(error, record);
                     }
@@ -84,10 +85,17 @@ var EnhanceDns = function (conf) {
                         if (err) {
                             return callback(err);
                         }
-                        cache.set('lookup_' + domain + '_' + family + '_' + hints + '_' +  all, Array.isArray(address) ? address : {
-                            'address' : address,
-                            'family' : family_r
-                        }, function () {
+                        var value;
+                        /*istanbul ignore next - "all" option require node 4+*/
+                        if (Array.isArray(address)) {
+                            value = address;
+                        } else {
+                            value = {
+                                'address' : address,
+                                'family' : family_r
+                            };
+                        }
+                        cache.set('lookup_' + domain + '_' + family + '_' + hints + '_' +  all, value, function () {
                             callback(err, address, family_r);
                         });
                     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,40 +43,47 @@ var EnhanceDns = function (conf) {
         dns.internalCache = cache;
 
         // override dns.lookup method
-        dns.lookup = function (domain, family, callback) {
+        dns.lookup = function (domain, options, callback) {
+            var family = 0;
+            var hints = 0;
+            var all = false;
             if (arguments.length === 2) {
-                callback = family;
-                family = 0;
-            } else if (!family) {
-                family = 0;
-            } else if (typeof family === 'object') {
-                if (!family.family) {
-                    family = 0;
-                } else {
-                    family = +family.family;
+                callback = options;
+                options = family;
+            } else if (typeof options === 'object') {
+                if (options.family) {
+                    family = +options.family;
                     if (family !== 4 && family !== 6) {
                         callback(new Error('invalid argument: `family` must be 4 or 6'));
                         return;
                     }
                 }
-            } else {
-                family = +family;
+                if (options.hints) {
+                    hints = +options.hints;
+                }
+                all = (options.all === true);
+            } else if (options) {
+                family = +options;
                 if (family !== 4 && family !== 6) {
                     callback(new Error('invalid argument: `family` must be 4 or 6'));
                     return;
                 }
             }
 
-            cache.get('lookup_' + domain + '_' + family, function (error, record) {
+            cache.get('lookup_' + domain + '_' + family + '_' + hints + '_' + all, function (error, record) {
                 if (record) {
+                    if (all) {
+                        return callback(error, record);
+                    }
                     return callback(error, record.address, record.family);
                 }
-                try {
-                    backup_object.lookup(domain, family, function (err, address, family_r) {
+
+                try{
+                    backup_object.lookup(domain, options, function (err, address, family_r) {
                         if (err) {
                             return callback(err);
                         }
-                        cache.set('lookup_' + domain + '_' + family, {
+                        cache.set('lookup_' + domain + '_' + family + '_' + hints + '_' +  all, all ? address : {
                             'address' : address,
                             'family' : family_r
                         }, function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,7 +72,8 @@ var EnhanceDns = function (conf) {
 
             cache.get('lookup_' + domain + '_' + family + '_' + hints + '_' + all, function (error, record) {
                 if (record) {
-                    if (all) {
+                    // Returns array if support "all" option and enabled.
+                    if (Array.isArray(record)) {
                         return callback(error, record);
                     }
                     return callback(error, record.address, record.family);
@@ -83,7 +84,7 @@ var EnhanceDns = function (conf) {
                         if (err) {
                             return callback(err);
                         }
-                        cache.set('lookup_' + domain + '_' + family + '_' + hints + '_' +  all, all ? address : {
+                        cache.set('lookup_' + domain + '_' + family + '_' + hints + '_' +  all, Array.isArray(address) ? address : {
                             'address' : address,
                             'family' : family_r
                         }, function () {

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ var params = ["www.yahoo.com", "www.google.com", "www.google.com", "ipv6.google.
     "google.com", "www.yahoo.com", "yahoo.com", "www.yahoo.com", "173.236.27.26"];
 var prefix = ['lookup_', 'resolve_', 'resolve4_', 'resolve6_', 'resolveMx_', 'resolveTxt_',
     'resolveSrv_', 'resolveNs_', 'resolveCname_', 'reverse_'];
-var suffix = ['_0', '_A', 'none', 'none', 'none', 'none', 'none', 'none', 'none', 'none'];
+var suffix = ['_0_0_false', '_A', 'none', 'none', 'none', 'none', 'none', 'none', 'none', 'none'];
 
 describe('dnscache main test suite', function() {
     this.timeout(10000); //dns queries are slow..
@@ -87,8 +87,8 @@ describe('dnscache main test suite', function() {
                     dns.lookup('127.0.0.1', { hints: dns.ADDRCONFIG }, function() {
                         dns.lookup('::1', { family: 6, hints: dns.ADDRCONFIG }, function() {
                             assert.ok(dns.internalCache);
-                            assert.equal(dns.internalCache.data['lookup_127.0.0.1_4'].hit, 1, 'hit should be 1 for family4');
-                            assert.equal(dns.internalCache.data['lookup_::1_6'].hit, 1, 'hit should be 1 for family6');
+                            assert.equal(dns.internalCache.data['lookup_127.0.0.1_4_0_false'].hit, 0, 'hit should be 0 for family4');
+                            assert.equal(dns.internalCache.data['lookup_::1_6_0_false'].hit, 0, 'hit should be 0 for family6');
                             done();
                         });
                     });
@@ -220,9 +220,9 @@ describe('dnscache main test suite', function() {
         testee.lookup('127.0.0.1', function() {
             //verify cache is created
             assert.ok(testee.internalCache);
-            assert.equal(testee.internalCache.data['lookup_127.0.0.1_0'].hit, 0, 'hit should be 0 for family4');
+            assert.equal(testee.internalCache.data['lookup_127.0.0.1_0_0_false'].hit, 0, 'hit should be 0 for family4');
             assert.ok(dns.internalCache);
-            assert.equal(dns.internalCache.data['lookup_127.0.0.1_0'].hit, 0, 'hit should be 0 for family4');
+            assert.equal(dns.internalCache.data['lookup_127.0.0.1_0_0_false'].hit, 0, 'hit should be 0 for family4');
             
             //verify default values
             assert.ok(conf);
@@ -232,4 +232,23 @@ describe('dnscache main test suite', function() {
         });
     });
 
+    it('should return array if lookup all', function(done) {
+        //if created from other tests
+        if (require('dns').internalCache) {
+            delete require('dns').internalCache;
+        }
+        var conf = {
+            enable: true
+        },
+        testee = require('../lib/index.js')(conf);
+        dns.lookup('127.0.0.1', {all: true}, function(err, addresses) {
+            assert.ok(Array.isArray(addresses));
+            assert.equal(testee.internalCache.data['lookup_127.0.0.1_0_0_true'].hit, 0, 'hit should be 0');
+            dns.lookup('127.0.0.1', {all: true}, function(err, addresses) {
+                assert.ok(Array.isArray(addresses));
+                assert.equal(testee.internalCache.data['lookup_127.0.0.1_0_0_true'].hit, 1, 'hit should be 1');
+                done();
+            });
+        });
+    });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,11 @@ var prefix = ['lookup_', 'resolve_', 'resolve4_', 'resolve6_', 'resolveMx_', 're
     'resolveSrv_', 'resolveNs_', 'resolveCname_', 'reverse_'];
 var suffix = ['_0_0_false', '_A', 'none', 'none', 'none', 'none', 'none', 'none', 'none', 'none'];
 
+// node v4+ dns.lookup support "all" option.
+var node_support_lookup_all = process.versions.node.split('.')[0] >= 4;
+// node v0.12+ dns.lookup support "hints" option.
+var node_support_lookup_hints = process.versions.node.split('.')[0] > 0 || process.versions.node.split('.')[1] >= 12;
+
 describe('dnscache main test suite', function() {
     this.timeout(10000); //dns queries are slow..
 
@@ -87,8 +92,9 @@ describe('dnscache main test suite', function() {
                     dns.lookup('127.0.0.1', { hints: dns.ADDRCONFIG }, function() {
                         dns.lookup('::1', { family: 6, hints: dns.ADDRCONFIG }, function() {
                             assert.ok(dns.internalCache);
-                            assert.equal(dns.internalCache.data['lookup_127.0.0.1_4_0_false'].hit, 0, 'hit should be 0 for family4');
-                            assert.equal(dns.internalCache.data['lookup_::1_6_0_false'].hit, 0, 'hit should be 0 for family6');
+                            var hit = node_support_lookup_hints ? 0 : 1;
+                            assert.equal(dns.internalCache.data['lookup_127.0.0.1_4_0_false'].hit, hit, 'hit should be ' + hit + ' for family4');
+                            assert.equal(dns.internalCache.data['lookup_::1_6_0_false'].hit, hit, 'hit should be ' + hit + ' for family6');
                             done();
                         });
                     });
@@ -233,7 +239,7 @@ describe('dnscache main test suite', function() {
     });
 
     // lookup's all option require node v4+.
-    if (process.versions.node.split('.')[0] >= 4) {
+    if (node_support_lookup_all) {
         it('should return array if lookup all', function(done) {
             //if created from other tests
             if (require('dns').internalCache) {

--- a/test/index.js
+++ b/test/index.js
@@ -232,23 +232,26 @@ describe('dnscache main test suite', function() {
         });
     });
 
-    it('should return array if lookup all', function(done) {
-        //if created from other tests
-        if (require('dns').internalCache) {
-            delete require('dns').internalCache;
-        }
-        var conf = {
-            enable: true
-        },
-        testee = require('../lib/index.js')(conf);
-        dns.lookup('127.0.0.1', {all: true}, function(err, addresses) {
-            assert.ok(Array.isArray(addresses));
-            assert.equal(testee.internalCache.data['lookup_127.0.0.1_0_0_true'].hit, 0, 'hit should be 0');
+    // lookup's all option require node v4+.
+    if (process.versions.node.split('.')[0] >= 4) {
+        it('should return array if lookup all', function(done) {
+            //if created from other tests
+            if (require('dns').internalCache) {
+                delete require('dns').internalCache;
+            }
+            var conf = {
+                enable: true
+            },
+                testee = require('../lib/index.js')(conf);
             dns.lookup('127.0.0.1', {all: true}, function(err, addresses) {
                 assert.ok(Array.isArray(addresses));
-                assert.equal(testee.internalCache.data['lookup_127.0.0.1_0_0_true'].hit, 1, 'hit should be 1');
-                done();
+                assert.equal(testee.internalCache.data['lookup_127.0.0.1_0_0_true'].hit, 0, 'hit should be 0');
+                dns.lookup('127.0.0.1', {all: true}, function(err, addresses) {
+                    assert.ok(Array.isArray(addresses));
+                    assert.equal(testee.internalCache.data['lookup_127.0.0.1_0_0_true'].hit, 1, 'hit should be 1');
+                    done();
+                });
             });
         });
-    });
+    }
 });


### PR DESCRIPTION
dns.lookup has a "all" option to returns all resolved addresses in an array.