### PR TITLE
failing test + fix for issue #19

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -79,10 +79,10 @@ var CacheObject = function (conf) {
             throw('cache.get callback is required.');
         }
 
-        if (!this.data[key]) {
-            return callback(null, undefined);
-        }
         next(function () {
+            if (!self.data[key]) {
+                return callback(null, undefined);
+            }
             var value;
             if (conf.ttl !== 0 && (Date.now() - self.data[key].ts) >= self.ttl) {
                 if (self.data[key].newer) {

--- a/test/testcache.js
+++ b/test/testcache.js
@@ -215,4 +215,18 @@ describe('caching tests', function() {
         });
     });
 
+    it('should not error when calling cache.get on an expired key twice in the same tick', function(done) {
+        var CacheObject = new mod_cache({
+            ttl: 1,
+            cachesize: 5
+        });
+        CacheObject.set(1, 1);
+        setTimeout(function() {
+            CacheObject.get(1, Function.prototype);
+            CacheObject.get(1, function() {
+                done();
+            });
+        }, 1200);
+    });
+
 });


### PR DESCRIPTION
The issue seems to occur when there is an expired key that hasn't been flushed from cache yet.
If `cache.get` gets called twice on the same tick then when checking for the key [here](https://github.com/yahoo/dnscache/blob/17250df71debb2ebcb5cadeef5f9b186a3fbe97d/lib/cache.js#L82-L84) it will still exist for both calls, however when the `next` callback of the first call is executed it will remove the key from the cache which will then cause the second call to fail.

The issue seems to be fixed  by just moving the check for the expired key into the `next` callback.