### PR TITLE
Fix concurrent DNS requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,6 +81,7 @@ var EnhanceDns = function (conf) {
         // insert cache object to the instance
         if(!dns.internalCache) {
             dns.internalCache = conf.cache ? new conf.cache(conf) : new CacheObject(conf);
+            callbackList = {};
         }
 
         var cache = dns.internalCache;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,19 @@ var CacheObject = require('./cache.js'),
  */
 var callbackList = {};
 
+// original function storage
+var backup_object = {
+    lookup : dns.lookup,
+    resolve : dns.resolve,
+    resolve4 : dns.resolve4,
+    resolve6 : dns.resolve6,
+    resolveMx : dns.resolveMx,
+    resolveTxt : dns.resolveTxt,
+    resolveSrv : dns.resolveSrv,
+    resolveNs : dns.resolveNs,
+    resolveCname : dns.resolveCname,
+    reverse : dns.reverse
+};
 
 /*
  * Make a deep copy of the supplied object. This function reliably copies only
@@ -52,29 +65,23 @@ var EnhanceDns = function (conf) {
         if (isNaN(conf.cachesize)) {
             conf.cachesize = 1000; //set default cache size to 1000 records max
         }
-        if (!conf.enable || conf.cachesize <= 0 || dns.internalCache) {
-            //cache already exists, means this code has already execute ie method are already overwritten
+
+        if(!conf.enable || conf.cachesize <= 0) {
+            delete dns.internalCache;
+            for(var key in backup_object) {
+                if (backup_object.hasOwnProperty(key)) {
+                    dns[key] = backup_object[key];
+                }
+            }
             return dns;
         }
 
-        // original function storage
-        var backup_object = {
-                lookup : dns.lookup,
-                resolve : dns.resolve,
-                resolve4 : dns.resolve4,
-                resolve6 : dns.resolve6,
-                resolveMx : dns.resolveMx,
-                resolveTxt : dns.resolveTxt,
-                resolveSrv : dns.resolveSrv,
-                resolveNs : dns.resolveNs,
-                resolveCname : dns.resolveCname,
-                reverse : dns.reverse
-            },
-            // cache storage instance
-            cache = conf.cache ? new conf.cache(conf) : new CacheObject(conf);
-
         // insert cache object to the instance
-        dns.internalCache = cache;
+        if(!dns.internalCache) {
+            dns.internalCache = conf.cache ? new conf.cache(conf) : new CacheObject(conf);
+        }
+
+        var cache = dns.internalCache;
 
         // override dns.lookup method
         dns.lookup = function (domain, options, callback) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,7 @@ var deepCopy = function (o) {
     } else {
         newObj = {};
         for (prop in o) {
+            /* istanbul ignore else */
             if (o.hasOwnProperty(prop)) {
                 newObj[prop] = deepCopy(o[prop]);
             }
@@ -69,6 +70,7 @@ var EnhanceDns = function (conf) {
         if(!conf.enable || conf.cachesize <= 0) {
             delete dns.internalCache;
             for(var key in backup_object) {
+                /* istanbul ignore else */
                 if (backup_object.hasOwnProperty(key)) {
                     dns[key] = backup_object[key];
                 }
@@ -337,6 +339,7 @@ var EnhanceDns = function (conf) {
                 var list = callbackList[key] = callbackList[key] || [];
                 list.push(callback);
 
+                /* istanbul ignore if */
                 if (list.length > 1) { return; }
 
                 try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,12 @@ var CacheObject = require('./cache.js'),
     dns = require('dns');
 
 /*
+ * Stores the list of callbacks waiting for a dns call.
+ */
+var callbackList = {};
+
+
+/*
  * Make a deep copy of the supplied object. This function reliably copies only
  * what is valid for a JSON object, array, or other element.
  */
@@ -49,7 +55,7 @@ var EnhanceDns = function (conf) {
             //cache already exists, means this code has already execute ie method are already overwritten
             return dns;
         }
-        
+
         // original function storage
         var backup_object = {
                 lookup : dns.lookup,
@@ -65,7 +71,7 @@ var EnhanceDns = function (conf) {
             },
             // cache storage instance
             cache = conf.cache ? new conf.cache(conf) : new CacheObject(conf);
-        
+
         // insert cache object to the instance
         dns.internalCache = cache;
 
@@ -94,23 +100,29 @@ var EnhanceDns = function (conf) {
                 }
             }
 
-            cache.get('lookup_' + domain + '_' + family, function (error, record) {
-                if (record) {
-                    callback(error, record.address, record.family);
-                } else {
-                    backup_object.lookup(domain, family, function (err, address, family_r) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            cache.set('lookup_' + domain + '_' + family, {
-                                'address' : address,
-                                'family' : family_r
-                            }, function () {
-                                callback(err, address, family_r);
-                            });
-                        }
-                    });
-                }
+            var key = 'lookup_' + domain + '_' + family;
+            cache.get(key, function (error, record) {
+                if (record) { return callback(error, record.address, record.family); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback);
+
+                if (list.length > 1) { return; }
+
+                backup_object.lookup(domain, family, function (err, address, family_r) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('lookup_' + domain + '_' + family, {
+                            'address' : address,
+                            'family' : family_r
+                        }, function () {
+                            list.forEach(function (cb) { cb(err, address, family_r); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
 
@@ -126,172 +138,226 @@ var EnhanceDns = function (conf) {
                 callback_new = type;
             }
 
-            cache.get('resolve_' + domain + '_' + type_new, function (error, record) {
-                if (record) {
-                    callback_new(error, deepCopy(record), true);
-                } else {
-                    backup_object.resolve(domain, type_new, function (err, addresses) {
-                        if (err) {
-                            callback_new(err);
-                        } else {
-                            cache.set('resolve_' + domain + '_' + type_new, addresses, function () {
-                                callback_new(err, deepCopy(addresses), false);
-                            });
-                        }
-                    });
-                }
+            var key = 'resolve_' + domain + '_' + type_new;
+            cache.get(key, function (error, record) {
+                if (record) { return callback_new(error, deepCopy(record), true); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback_new);
+
+                if (list.length > 1) { return; }
+
+                backup_object.resolve(domain, type_new, function (err, addresses) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('resolve_' + domain + '_' + type_new, addresses, function () {
+                            list.forEach(function (cb) { cb(err, deepCopy(addresses), false); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
 
         // override dns.resolve4 method
         dns.resolve4 = function (domain, callback) {
-            cache.get('resolve4_' + domain, function (error, record) {
-                if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    backup_object.resolve4(domain, function (err, addresses) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            cache.set('resolve4_' + domain, addresses, function () {
-                                callback(err, deepCopy(addresses));
-                            });
-                        }
-                    });
-                }
+            var key = 'resolve4_' + domain;
+            cache.get(key, function (error, record) {
+                if (record) { return callback(error, deepCopy(record)); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback);
+
+                if (list.length > 1) { return; }
+
+                backup_object.resolve4(domain, function (err, addresses) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('resolve4_' + domain, addresses, function () {
+                            list.forEach(function (cb) { cb(err, deepCopy(addresses)); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
 
         // override dns.resolve6 method
         dns.resolve6 = function (domain, callback) {
-            cache.get('resolve6_' + domain, function (error, record) {
-                if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    backup_object.resolve6(domain, function (err, addresses) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            cache.set('resolve6_' + domain, addresses, function () {
-                                callback(err, deepCopy(addresses));
-                            });
-                        }
-                    });
-                }
+            var key = 'resolve6_' + domain;
+            cache.get(key, function (error, record) {
+                if (record) { return callback(error, deepCopy(record)); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback);
+
+                if (list.length > 1) { return; }
+
+                backup_object.resolve6(domain, function (err, addresses) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('resolve6_' + domain, addresses, function () {
+                            list.forEach(function (cb) { cb(err, deepCopy(addresses)); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
 
         // override dns.resolveMx method
         dns.resolveMx = function (domain, callback) {
-            cache.get('resolveMx_' + domain, function (error, record) {
-                if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    backup_object.resolveMx(domain, function (err, addresses) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            cache.set('resolveMx_' + domain, addresses, function () {
-                                callback(err, deepCopy(addresses));
-                            });
-                        }
-                    });
-                }
+            var key = 'resolveMx_' + domain;
+            cache.get(key, function (error, record) {
+                if (record) { return callback(error, deepCopy(record)); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback);
+
+                if (list.length > 1) { return; }
+
+                backup_object.resolveMx(domain, function (err, addresses) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('resolveMx_' + domain, addresses, function () {
+                            list.forEach(function (cb) { cb(err, deepCopy(addresses)); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
 
         // override dns.resolveTxt method
         dns.resolveTxt = function (domain, callback) {
-            cache.get('resolveTxt_' + domain, function (error, record) {
-                if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    backup_object.resolveTxt(domain, function (err, addresses) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            cache.set('resolveTxt_' + domain, addresses, function () {
-                                callback(err, deepCopy(addresses));
-                            });
-                        }
-                    });
-                }
+            var key = 'resolveTxt_' + domain;
+            cache.get(key, function (error, record) {
+                if (record) { return callback(error, deepCopy(record)); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback);
+
+                if (list.length > 1) { return; }
+
+                backup_object.resolveTxt(domain, function (err, addresses) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('resolveTxt_' + domain, addresses, function () {
+                            list.forEach(function (cb) { cb(err, deepCopy(addresses)); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
 
         // override dns.resolveSrv method
         dns.resolveSrv = function (domain, callback) {
-            cache.get('resolveSrv_' + domain, function (error, record) {
-                if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    backup_object.resolveSrv(domain, function (err, addresses) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            cache.set('resolveSrv_' + domain, addresses, function () {
-                                callback(err, deepCopy(addresses));
-                            });
-                        }
-                    });
-                }
+            var key = 'resolveSrv_' + domain;
+            cache.get(key, function (error, record) {
+                if (record) { return callback(error, deepCopy(record)); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback);
+
+                if (list.length > 1) { return; }
+
+                backup_object.resolveSrv(domain, function (err, addresses) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('resolveSrv_' + domain, addresses, function () {
+                            list.forEach(function (cb) { cb(err, deepCopy(addresses)); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
 
         // override dns.resolveNs method
         dns.resolveNs = function (domain, callback) {
-            cache.get('resolveNs_' + domain, function (error, record) {
-                if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    backup_object.resolveNs(domain, function (err, addresses) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            cache.set('resolveNs_' + domain, addresses, function () {
-                                callback(err, deepCopy(addresses));
-                            });
-                        }
-                    });
-                }
+            var key = 'resolveNs_' + domain;
+            cache.get(key, function (error, record) {
+                if (record) { return callback(error, deepCopy(record)); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback);
+
+                if (list.length > 1) { return; }
+
+                backup_object.resolveNs(domain, function (err, addresses) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('resolveNs_' + domain, addresses, function () {
+                            list.forEach(function (cb) { cb(err, deepCopy(addresses)); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
 
         // override dns.resolveCname method
         dns.resolveCname = function (domain, callback) {
-            cache.get('resolveCname_' + domain, function (error, record) {
-                if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    backup_object.resolveCname(domain, function (err, addresses) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            cache.set('resolveCname_' + domain, addresses, function () {
-                                callback(err, deepCopy(addresses));
-                            });
-                        }
-                    });
-                }
+            var key = 'resolveCname_' + domain;
+            cache.get(key, function (error, record) {
+                if (record) { return callback(error, deepCopy(record)); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback);
+
+                if (list.length > 1) { return; }
+
+                backup_object.resolveCname(domain, function (err, addresses) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('resolveCname_' + domain, addresses, function () {
+                            list.forEach(function (cb) { cb(err, deepCopy(addresses)); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
 
         // override dns.reverse method
         dns.reverse = function (ip, callback) {
-            cache.get('reverse_' + ip, function (error, record) {
-                if (record) {
-                    callback(error, deepCopy(record));
-                } else {
-                    backup_object.reverse(ip, function (err, addresses) {
-                        if (err) {
-                            callback(err);
-                        } else {
-                            cache.set('reverse_' + ip, addresses, function () {
-                                callback(err, deepCopy(addresses));
-                            });
-                        }
-                    });
-                }
+            var key = 'reverse_' + ip;
+            cache.get(key, function (error, record) {
+                if (record) { return callback(error, deepCopy(record)); }
+
+                var list = callbackList[key] = callbackList[key] || [];
+                list.push(callback);
+
+                if (list.length > 1) { return; }
+
+                backup_object.reverse(ip, function (err, addresses) {
+                    if (err) {
+                        list.forEach(function (cb) { cb(err); });
+                        delete callbackList[key];
+                    } else {
+                        cache.set('reverse_' + ip, addresses, function () {
+                            list.forEach(function (cb) { cb(err, deepCopy(addresses)); });
+                            delete callbackList[key];
+                        });
+                    }
+                });
             });
         };
         return dns;

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ var assert = require('assert'),
         ttl: 300,
         cachesize: 1000
     });
-    
+
 var dns = require('dns');
 var methods = [dns.lookup, dns.resolve, dns.resolve4, dns.resolve6, dns.resolveMx,dns.resolveTxt,
     dns.resolveSrv, dns.resolveNs, dns.resolveCname, dns.reverse];
@@ -72,7 +72,7 @@ describe('dnscache main test suite', function() {
 
     it('require again and verify cache is same as before', function (done) {
         require('../lib/index.js')({
-            enable: true, 
+            enable: true,
             ttl: 300,
             cachesize: 1000
         });
@@ -124,7 +124,8 @@ describe('dnscache main test suite', function() {
     });
 
     it('should error on invalid reverse lookup', function(done) {
-        dns.reverse('1.1.1.1', function(err) {
+        // from the TEST-NET-1 block, as specified in https://tools.ietf.org/html/rfc5737
+        dns.reverse('192.0.2.0', function(err) {
             assert.ok((err instanceof Error));
             done();
         });
@@ -180,7 +181,7 @@ describe('dnscache main test suite', function() {
             done();
         });
     });
-    
+
     it('should not cache if enabled: false', function(done) {
         //if created from other tests
         if (require('dns').internalCache) {
@@ -222,14 +223,14 @@ describe('dnscache main test suite', function() {
             enable: true
         },
         testee = require('../lib/index.js')(conf);
-        
+
         testee.lookup('127.0.0.1', function() {
             //verify cache is created
             assert.ok(testee.internalCache);
             assert.equal(testee.internalCache.data['lookup_127.0.0.1_0_0_false'].hit, 0, 'hit should be 0 for family4');
             assert.ok(dns.internalCache);
             assert.equal(dns.internalCache.data['lookup_127.0.0.1_0_0_false'].hit, 0, 'hit should be 0 for family4');
-            
+
             //verify default values
             assert.ok(conf);
             assert.equal(conf.ttl, 300);

--- a/test/testcoverage.js
+++ b/test/testcoverage.js
@@ -66,7 +66,7 @@ describe('dnscache additional tests for full coverage', function() {
                     callback(null, result);
                 });
             }, function(err, results) {
-                assert.deepStrictEqual(results[0], results[1], "expected same result from cached query");
+                (assert.deepStrictEqual || assert.deepEqual)(results[0], results[1], "expected same result from cached query");
                 itemDone(null);
             });
         }, function() {

--- a/test/testcoverage.js
+++ b/test/testcoverage.js
@@ -1,0 +1,87 @@
+/* jshint ignore:start */
+// /*global describe, it*/
+
+var globalOptions = {
+    enable: true,
+    ttl: 300,
+    cachesize: 1000
+};
+var assert = require("assert");
+var dns = require('../lib/index.js')(globalOptions);
+
+function prepare(options) {
+    if (!options) {
+        options = globalOptions;
+    }
+    //if created from other tests
+    if (dns.internalCache) {
+        delete dns.internalCache;
+    }
+    dns = require("../lib/index.js")(options);
+    return dns;
+}
+
+describe('dnscache additional tests for full coverage', function() {
+    this.timeout(10000); //dns queries are slow..
+
+    it("should convert family string to number", function(done) {
+        prepare();
+        dns.lookup("127.0.0.1", "4", function() {
+            dns.lookup("127.0.0.1", "6", function() {
+                done();
+            });
+        });
+    });
+
+    it("coverage: options is undefined", function(done) {
+        prepare();
+        dns.lookup("127.0.0.1", undefined, function() {
+            done();
+        });
+    });
+
+    it("coverage: custom cache object", function(done) {
+        var cacheClass = require("../lib/cache.js");
+        prepare({enable: true, cache: cacheClass});
+        done();
+    });
+
+    it("coverage: simultaneous requests", function(done) {
+        prepare();
+        var methods = [
+            ["lookup", "127.0.0.1"],
+            ["resolve", "localhost"],
+            ["resolve4", "localhost"],
+            ["resolve6", "localhost"],
+            ["resolveMx", "yahoo.com"],
+            ["resolveTxt", "yahoo.com"],
+            ["resolveNs", "yahoo.com"],
+            ["resolveCname", "www.yahoo.com"],
+            ["reverse", "1.1.1.1"]
+        ];
+        var concurrent = 0;
+        function callback() {
+            concurrent--;
+            if (concurrent === 0) {
+                done();
+            }
+        }
+        for (var m = 0; m < methods.length; m++) {
+            (function(method) {
+                var results = [];
+                for (var i = 0; i < 2; i++) {
+                    concurrent++;
+                    dns[method[0]](method[1], function(err, result) {
+                        assert.ok(!err);
+                        results.push(result);
+                        if (results.length == 2) {
+                            assert.deepStrictEqual(results[0], results[1], "expected same result from cached query");
+                        }
+                        callback();
+                    });
+                }
+            })(methods[m]);
+        }
+    });
+});
+/* jshint ignore:end */

--- a/test/testcoverage.js
+++ b/test/testcoverage.js
@@ -63,11 +63,10 @@ describe('dnscache additional tests for full coverage', function() {
         async.eachSeries(methods, function(method, itemDone) {
             async.times(2, function(i, callback) {
                 dns[method[0]](method[1], function(err, result) {
-                    assert.ok(!err);
                     callback(null, result);
                 });
             }, function(err, results) {
-                require("assert").deepStrictEqual(results[0], results[1], "expected same result from cached query");
+                assert.deepStrictEqual(results[0], results[1], "expected same result from cached query");
                 itemDone(null);
             });
         }, function() {


### PR DESCRIPTION
[PR #6](https://github.com/yahoo/dnscache/pull/6) was not merged due to not being updated as per the comments suggested, but I needed this feature, so I did it myself.

I believe I have successfully integrated esnunes's changes as well as addressing the comments raising in the previous pull request.

I have not tested this thoroughly, but it does appear to do what I need it to do: initiating 100 simultaneous requests to a website and analysing the traffic with Wireshark reveals only 2 DNS requests are made, one for the IPv4 address, one for the IPv6 address.

(cc @goloroden)