### PR TITLE
copy the addresses array from dns.lookup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,7 @@ var EnhanceDns = function (conf) {
                         var value;
                         /*istanbul ignore next - "all" option require node 4+*/
                         if (Array.isArray(address)) {
-                            value = address;
+                            value = deepCopy(address);
                         } else {
                             value = {
                                 'address' : address,

--- a/test/index.js
+++ b/test/index.js
@@ -260,5 +260,22 @@ describe('dnscache main test suite', function() {
                 });
             });
         });
+
+        it('should return an array copy if lookup all', function(done) {
+            //if created from other tests
+            if (require('dns').internalCache) {
+                delete require('dns').internalCache;
+            }
+            var conf = {
+                enable: true
+            },
+                testee = require('../lib/index.js')(conf);
+            dns.lookup('127.0.0.1', {all: true}, function(err, addresses) {
+                assert.ok(Array.isArray(addresses));
+                addresses.pop();
+                assert.equal(testee.internalCache.data['lookup_127.0.0.1_0_0_true'].val.length, 1, 'length should be 1');
+                done();
+            });
+        });
     }
 });


### PR DESCRIPTION
We're using this module along with [mssql](https://github.com/tediousjs/node-mssql) / [tedious](https://github.com/tediousjs/tedious) which has revealed a bug in `dnscache`. The problem is that the `addresses` array returned from a `dns.lookup(..., {all: true}, ...)` call is not copied before storing into cache. So when [tedious performs a lookup](https://github.com/tediousjs/tedious/blob/7be36ee7504fd63ff8c73f59cc33f62837dbb40f/src/connector.js#L43) and then [mutates the `addresses` array](https://github.com/tediousjs/tedious/blob/7be36ee7504fd63ff8c73f59cc33f62837dbb40f/src/connector.js#L120), it also mutates the array held in cache.

This PR adds a test case around this scenario as well as makes a copy of the `addresses` array before storing it into cache.

@sylvio I saw you recently reviewed another PR so hoping you can review this one as well.